### PR TITLE
Bump POM version, support JAR creation, and support Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language:  java
+
+cache:
+  directories:
+  - "$HOME/.m2"
+
+jobs:
+  include:
+    - stage: test
+      jdk: openjdk8
+      before_install:
+        - curl -L -o hapl-obs.jar $HAPL_OBS_URL
+        - mvn install:install-file -Dfile=hapl-obs.jar -Dpackaging=jar -DgroupId=workshop.haplotype -DartifactId=hapl-obs -Dversion=$HAPL_OBS_VERSION 
+
+    - jdk: openjdk11
+      before_install:
+        - curl -L -o hapl-obs.jar $HAPL_OBS_URL
+        - mvn install:install-file -Dfile=hapl-obs.jar -Dpackaging=jar -DgroupId=workshop.haplotype -DartifactId=hapl-obs -Dversion=$HAPL_OBS_VERSION 
+
+    - stage: deploy
+      if: tag IS present
+      jdk: openjdk11
+      install: skip
+      script: skip
+      if: tag IS present
+      before_deploy:
+        - mvn clean
+        - sed -i "s|<version>0.0.1-SNAPSHOT</version>|<version>${TRAVIS_TAG}</version>|" pom.xml
+        - mvn package -Dmaven.test.skip=true
+
+      deploy:
+        provider: releases
+        api_key: $GITHUB_OAUTH_TOKEN
+        skip_cleanup: true
+        file_glob: true
+        file:
+          - "target/*.jar"
+        on:
+          tags: true
+          all_branches: true

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   		<dependency>
   			<groupId>workshop.haplotype</groupId>
   			<artifactId>hapl-obs</artifactId>
-  			<version>0.0.1-SNAPSHOT</version>
+ 			<version>0.2</version>
   		</dependency>
   	</dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,30 @@
   					<source>1.8</source>
   					<target>1.8</target>
   				</configuration>
-  			</plugin>
-  		</plugins>
+			</plugin>
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.1.1</version>
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+					<archive>
+						<manifest>
+							<mainClass>workshop.panel.driver.DriverForRunValidation</mainClass>
+						</manifest>
+					</archive>
+				</configuration>
+				<executions>
+					<execution>
+						<id>make-assembly</id>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
   	</build>
 </project>


### PR DESCRIPTION
This pull request does a few things.

• First, it increases the POM version.

• Second, it enables the Maven assembly plugin.  This allows for creating single JAR files that contain hlaGenotypeEvaluator _and_ all of the dependencies.  It means you can ship the single JAR file to someone else, and they can run the software (without needing to have the source, and a full Maven installation).

• Third, it adds support for testing via Travis CI.  Once you enable this repository on Travis, any pushes to the GitHub repository will trigger a build and test.  And any tags you push will generate a build, test, and JAR creation.  The finished JAR will then appear as a GitHub release.